### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default reviewers for each PR
+*     @Chronocook @jameslamb


### PR DESCRIPTION
Creating CODEOWNERS file for alerting the default reviewers in the event of PR Submission. Closes #47 